### PR TITLE
Add: settings for celery and rabbitmq

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -11,6 +11,9 @@ TEMPLATE_DEBUG = DEBUG
 ADMINS = None
 MANAGERS = None
 
+import djcelery
+djcelery.setup_loader()
+
 # Set this in settings_local.py
 DATABASES = {
     'default': {
@@ -164,6 +167,7 @@ INSTALLED_APPS = (
     'south',
     'sorl.thumbnail',
     'traveler',
+    'djcelery',
 )
 
 ### LOCAST SETTINGS ###

--- a/settings_local.py.example
+++ b/settings_local.py.example
@@ -20,6 +20,13 @@ DATABASES = {
     }
 }
 
+#Broker information for RabbitMQ
+BROKER_HOST = '127.0.0.1'
+BROKER_PORT = 5672
+BROKER_USER = 'locast'
+BROKER_PASSWORD = 'locast'
+BROKER_VHOST = 'locast_core'
+
 LANGUAGE_CODE = 'en-us'
 LANGUAGES = (
     ('en', 'English'),


### PR DESCRIPTION
Here is the celery items you requested.

Adds django_celery as an installed app and suggests default broker
settings in settings_local.py
